### PR TITLE
Add cache tags for child products

### DIFF
--- a/code/Cache/Helper/Data.php
+++ b/code/Cache/Helper/Data.php
@@ -72,4 +72,25 @@ class Made_Cache_Helper_Data extends Mage_Core_Helper_Abstract
         return (bool)Mage::getModel('core/message_collection')
                 ->count();
     }
+    
+    /**
+     * Get product IDs for related products (useful when generating cache tags)
+     * 
+     * @param array $productIds
+     * @return array
+     */
+    public function getChildProductIds($productIds)
+    {
+        $resource = Mage::getSingleton('core/resource');
+        $read = $resource->getConnection('core_read');
+        $select = $read->select()
+                ->from($resource->getTableName('catalog/product_super_link'), array('product_id'))
+                ->where('parent_id IN(?)', $productIds);
+        
+        $childIds = array();
+        foreach ($read->fetchAll($select) AS $link) {
+            $childIds[] = $link['product_id'];
+        }
+        return $childIds;
+    }    
 }

--- a/code/Cache/Model/Observer/Catalog.php
+++ b/code/Cache/Model/Observer/Catalog.php
@@ -126,9 +126,19 @@ class Made_Cache_Model_Observer_Catalog
 
         $_toolbar->setCollection($productCollection);
 
+        $productIds = array();
         foreach ($productCollection as $_product) {
             $tags[] = Mage_Catalog_Model_Product::CACHE_TAG."_".$_product->getId();
+            $productIds[] = $_product->getId();
         }
+        
+        if (!empty($productIds)) {
+            $childIds = Mage::helper('cache')->getChildProductIds($productIds);
+            foreach ($childIds as $childId) {
+                $tags[] = Mage_Catalog_Model_Product::CACHE_TAG . '_' . $childId;
+            }
+        }
+        
         $block->setData('cache_tags', $tags);
 
         // Set cache key


### PR DESCRIPTION
This makes sure that the catalog cache can be cleared for products with associated products (ie. configurable products) when any of the associated products are updated. Fixes a bug where the stock availability of the "parent" product is not current in the cache when the associated products are updated.
