### PR TITLE
Fixed issue with cache ttl for content-type application/json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "madepeople/made-cache",
+    "name": "webbhuset/made-cache",
     "license": "BSD-4-Clause",
     "type": "magento-module",
     "description": "Block Cache & Varnish extension for Magento",
@@ -15,7 +15,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packages.firegento.com"
+            "url": "https://github.com/webbhuset/Made_Cache.git"
         }
     ]
 }

--- a/src/code/Cache/Model/VarnishObserver.php
+++ b/src/code/Cache/Model/VarnishObserver.php
@@ -77,6 +77,14 @@ class Made_Cache_Model_VarnishObserver
         if (!Mage::helper('cache/varnish')->shouldUse()) {
             return;
         }
+        $headers = Mage::app()->getResponse()->getHeaders();
+        foreach ($headers as $header) {
+            if (strtolower($header['name']) == 'content-type') {
+                if ($header['value'] == 'application/json') {
+                    return;
+                }
+            }
+        }
 
         $block = $observer->getEvent()->getBlock();
 

--- a/src/code/Cache/etc/magento.vcl
+++ b/src/code/Cache/etc/magento.vcl
@@ -170,6 +170,9 @@ sub vcl_fetch {
 
             # Don't cache expire headers, we maintain those differently
             unset beresp.http.expires;
+        } elsif (beresp.http.Content-Type ~ "application/json") {
+            set beresp.ttl = std.duration(beresp.http.X-Made-Cache-Ttl, 0s);
+            unset beresp.http.expires;
         } else {
             # TTL for static content
             set beresp.ttl = 1w;


### PR DESCRIPTION
This fixes some issues with ajax requests getting cached with the ttl for static content (1w) instead of the settings in Magento.