### PR TITLE
Fixed issue with cache ttl for content-type application/json

### DIFF
--- a/src/code/Cache/etc/magento.vcl
+++ b/src/code/Cache/etc/magento.vcl
@@ -170,6 +170,9 @@ sub vcl_fetch {
 
             # Don't cache expire headers, we maintain those differently
             unset beresp.http.expires;
+        } elsif (beresp.http.Content-Type ~ "application/json") {
+            set beresp.ttl = std.duration(beresp.http.X-Made-Cache-Ttl, 0s);
+            unset beresp.http.expires;
         } else {
             # TTL for static content
             set beresp.ttl = 1w;


### PR DESCRIPTION
This fixes some issues with ajax requests getting cached with the ttl for static content (1w) instead of the settings in Magento.
