### PR TITLE
Fix esi on noncached pages and when Content type is application/json

### DIFF
--- a/src/code/Cache/Block/Messages.php
+++ b/src/code/Cache/Block/Messages.php
@@ -11,8 +11,12 @@ class Made_Cache_Block_Messages extends Mage_Core_Block_Messages
 {
     protected function _toHtml()
     {
-        if (Mage::helper('cache/varnish')->shouldUse()
-                && !$this->getBypassVarnish()) {
+        $helper = Mage::helper('cache/varnish');
+        $request = Mage::app()->getRequest();
+        if ($helper->shouldUse()
+            && $helper->getRequestTtl($request)
+            && !$this->getBypassVarnish()
+        ) {
             return Mage::helper('cache/varnish')
                     ->getEsiTag('madecache/varnish/messages');
         }

--- a/src/code/Cache/Model/VarnishObserver.php
+++ b/src/code/Cache/Model/VarnishObserver.php
@@ -60,6 +60,11 @@ class Made_Cache_Model_VarnishObserver
         if (!Mage::helper('cache/varnish')->shouldUse()) {
             return;
         }
+        $request = Mage::app()->getRequest();
+
+        if (!Mage::helper('cache/varnish')->getRequestTtl($request)) {
+            return;
+        }
 
         $observer->getEvent()
             ->getLayout()

--- a/src/code/Cache/Model/VarnishObserver.php
+++ b/src/code/Cache/Model/VarnishObserver.php
@@ -77,6 +77,14 @@ class Made_Cache_Model_VarnishObserver
         if (!Mage::helper('cache/varnish')->shouldUse()) {
             return;
         }
+        $headers = Mage::app()->getResponse()->getHeaders();
+        foreach ($headers as $header) {
+            if (strtolower($header['name']) == 'content-type') {
+                if ($header['value'] == 'application/json') {
+                    return;
+                }
+            }
+        }
 
         $block = $observer->getEvent()->getBlock();
 


### PR DESCRIPTION
This branch disables ESI processing on non cached pages (ttl = 0) and responses with Content-Type application/json.
This also fixes an issue with session messages disappearing on non cached pages. (eg account/login)

If you enter the wrong password on account/login the message you don't get any message due to [this](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Customer/controllers/AccountController.php#L129) line. It removes all messages from the session and when madecache/varnish/messages tries to render the message block there is nothing left.