### PR TITLE
Changed event for purgeUserCache on quote_item_qty_set_after

### DIFF
--- a/src/code/Cache/etc/config.xml
+++ b/src/code/Cache/etc/config.xml
@@ -221,7 +221,7 @@
                     </clear_varnish_user_cache>
                 </observers>
             </customer_logout>
-            <sales_quote_item_qty_set_after>
+            <sales_quote_item_save_after>
                 <observers>
                     <clear_varnish_user_cache>
                         <type>singleton</type>
@@ -229,7 +229,16 @@
                         <method>purgeUserCache</method>
                     </clear_varnish_user_cache>
                 </observers>
-            </sales_quote_item_qty_set_after>
+            </sales_quote_item_save_after>
+            <sales_quote_item_delete_after>
+                <observers>
+                    <clear_varnish_user_cache>
+                        <type>singleton</type>
+                        <class>cache/varnishObserver</class>
+                        <method>purgeUserCache</method>
+                    </clear_varnish_user_cache>
+                </observers>
+            </sales_quote_item_delete_after>
             <catalog_product_compare_add_product>
                 <observers>
                     <clear_varnish_user_cache>


### PR DESCRIPTION
If you add a cart sidebar the event `sales_quote_item_qty_set_after` is dispatched on every page which results in the user cache being cleared on every page.
This event is dispatched when a quote item collection is loaded. (from quote item colleciton [_afterLoad](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php#L139) to [_assignProducts](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Sales/Model/Resource/Quote/Item/Collection.php#L231) to [checkData](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Sales/Model/Quote/Item/Abstract.php#L268) to [setQty](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Sales/Model/Quote/Item.php#L313))

I've changed this to use item save and item delete events instead. It seems to work in our implementation but I am happy if you have any input on this.

Thanks