### PR TITLE
PHP7 Redis session fix

### DIFF
--- a/src/code/Cache/Redis/Session.php
+++ b/src/code/Cache/Redis/Session.php
@@ -97,8 +97,8 @@ class Made_Cache_Redis_Session
             return false;
         }
         $client = $this->_getClient();
-        $result = $client->del($id);
-        return empty($result);
+        $deleteCount = $client->del($id);
+        return $deleteCount > 0;
     }
 
     /**


### PR DESCRIPTION
Session `destroy()` should return true on success. In PHP7 `session_regenerate_id()` broke because it did not. This is a fix for that.